### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Supabase MCP Server
+[![smithery badge](https://smithery.ai/badge/@joshuarileydev/supabase-mcp-server)](https://smithery.ai/server/@joshuarileydev/supabase-mcp-server)
 
 A Model Context Protocol (MCP) server that provides programmatic access to the Supabase Management API. This server allows AI models and other clients to manage Supabase projects and organizations through a standardized interface.
 
@@ -17,6 +18,16 @@ A Model Context Protocol (MCP) server that provides programmatic access to the S
 - Create new organizations
 
 ## Installation
+
+### Installing via Smithery
+
+To install Supabase Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@joshuarileydev/supabase-mcp-server):
+
+```bash
+npx -y @smithery/cli install @joshuarileydev/supabase-mcp-server --client claude
+```
+
+### Manual Installation
 Add the following to your Claude Config JSON file
 ```
 {


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Supabase Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@joshuarileydev/supabase-mcp-server

Let me know if any tweaks have to be made!